### PR TITLE
fix of dependecies for java9/10

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -35,6 +35,21 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
I had to add these dependencies in order to successfully compile with java10 (OpenJDK), however running this with java8 seems to make problems. I am not sure how it can be made compatible with both at the same time. Just wanted to raise this possible issue. Might also be worth just completely migrating to java10.